### PR TITLE
Add "Other" field

### DIFF
--- a/dap/src/events.rs
+++ b/dap/src/events.rs
@@ -424,4 +424,27 @@ pub enum Event {
   ///
   /// Specification: [Thread event](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Thread)
   Thread(ThreadEventBody),
+  #[cfg(feature = "client")]
+  /// Event for an unknown event type
+  #[serde(untagged)]
+  Unknown { event: String, body: Value },
+}
+
+#[cfg(test)]
+#[cfg(feature = "client")]
+mod tests {
+  use super::Event;
+
+  #[test]
+  fn unknown_event() {
+    let input = r#"{"event":"unknown","body":{}}"#;
+    let event: Event = serde_json::from_str(input).unwrap();
+    match event {
+      Event::Unknown { event, body } => {
+        assert_eq!(event, "unknown");
+        assert_eq!(body, serde_json::json!({}));
+      }
+      other => panic!("unexpected event: {:?}", other),
+    }
+  }
 }

--- a/dap/src/events.rs
+++ b/dap/src/events.rs
@@ -427,7 +427,7 @@ pub enum Event {
   #[cfg(feature = "client")]
   /// Event for an unknown event type
   #[serde(untagged)]
-  Unknown { event: String, body: Value },
+  Other { event: String, body: Value },
 }
 
 #[cfg(test)]
@@ -440,7 +440,7 @@ mod tests {
     let input = r#"{"event":"unknown","body":{}}"#;
     let event: Event = serde_json::from_str(input).unwrap();
     match event {
-      Event::Unknown { event, body } => {
+      Event::Other { event, body } => {
         assert_eq!(event, "unknown");
         assert_eq!(body, serde_json::json!({}));
       }

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -995,7 +995,7 @@ pub enum Command {
   #[cfg(feature = "client")]
   /// Event for an unknown request type
   #[serde(untagged)]
-  Unknown { command: String, arguments: Value },
+  Other { command: String, arguments: Value },
 }
 
 /// Represents a request from a client.
@@ -1193,7 +1193,7 @@ mod tests {
 
   #[test]
   fn unknown_command() {
-    let command = Command::Unknown {
+    let command = Command::Other {
       command: "foo".to_string(),
       arguments: serde_json::json!({
           "a": 10,

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 
 #[cfg(feature = "client")]
 use serde::Deserialize;
+#[cfg(feature = "client")]
+#[cfg(not(feature = "integration_testing"))]
 use serde_json::Value;
 
 use crate::types::{
@@ -629,7 +631,7 @@ pub enum ResponseBody {
   #[cfg(not(feature = "integration_testing"))]
   /// Event for an unknown request type
   #[serde(untagged)]
-  Unknown { command: String, body: Value },
+  Other { command: String, body: Value },
 }
 
 /// Represents response to the client.
@@ -721,7 +723,7 @@ mod test {
   fn unknown_response_body() {
     let s = r#"{"command": "unknown", "body": {"a": 10}}"#;
     let body: ResponseBody = serde_json::from_str(s).unwrap();
-    let ResponseBody::Unknown { command, body } = body else {
+    let ResponseBody::Other { command, body } = body else {
       panic!("invalid type");
     };
     assert_eq!(command, "unknown");

--- a/integration_tests/build.rs
+++ b/integration_tests/build.rs
@@ -34,6 +34,8 @@ fn main() -> DynResult<()> {
     // This is something that jsonschema should explicitly develop support for.
     "LoadedSources",
     "Scopes",
+    // custom types that are not included in the spec
+    "Other",
   ]
   .iter()
   .map(|s| s.to_string())


### PR DESCRIPTION
When serializing/deserializing, some events/requests/responses (mostly events) are not part of the spec. This means we need another type to handle this case.

- **Add event type for unknown events**
- **Add unknown command type**
- **Add Unknown variant for ResponseBody**
- **Rename Unknown -> Other**
