### PR TITLE
Support sending requests via Sendable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,22 +36,22 @@ jobs:
       run: |
         cargo test --verbose
 
-  publish:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+  # publish:
+  #   needs: build
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Login to Crates.io
-      uses: actions-rs/cargo@v1
-      with:
-        command: login
-        args: ${{ secrets.CRATES_IO_TOKEN }}
+  #   - name: Login to Crates.io
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: login
+  #       args: ${{ secrets.CRATES_IO_TOKEN }}
 
-    - name: Publish to Crates.io
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: --package dap
+  #   - name: Publish to Crates.io
+  #     uses: actions-rs/cargo@v1
+  #     with:
+  #       command: publish
+  #       args: --package dap

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: rustfmt
+
     - name: Format check
       run: cargo fmt -- --check
 
@@ -31,7 +35,6 @@ jobs:
     - name: Run tests
       run: |
         cargo test --verbose
-        cargo test --verbose --features client
 
   publish:
     needs: build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["dap", "integration_tests"]
+resolver = "2"

--- a/dap/Cargo.toml
+++ b/dap/Cargo.toml
@@ -24,4 +24,3 @@ rand = { version = "0.*", optional = true }
 
 [features]
 integration_testing = ["fake", "rand"]
-client = []

--- a/dap/src/base_message.rs
+++ b/dap/src/base_message.rs
@@ -1,15 +1,13 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "client")]
-use serde::Deserialize;
-
-use crate::{events::Event, responses::Response, reverse_requests::ReverseRequest};
+use crate::{
+  events::Event, requests::Command, responses::Response, reverse_requests::ReverseRequest,
+};
 
 /// Represents the base protocol message, in which all other messages are wrapped.
 ///
 /// Specification: [Response](https://microsoft.github.io/debug-adapter-protocol/specification)
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BaseMessage {
   /// Sequence number of the message. The `seq` for
@@ -19,12 +17,12 @@ pub struct BaseMessage {
   pub message: Sendable,
 }
 
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
 pub enum Sendable {
   Response(Response),
+  Request(Command),
   Event(Event),
   ReverseRequest(ReverseRequest),
 }

--- a/dap/src/events.rs
+++ b/dap/src/events.rs
@@ -1,8 +1,5 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-#[cfg(feature = "client")]
-use serde::Deserialize;
 
 use crate::types::{
   Breakpoint, BreakpointEventReason, Capabilities, InvalidatedAreas, LoadedSourceEventReason,
@@ -11,8 +8,7 @@ use crate::types::{
 };
 
 //// Arguments for a Breakpoint event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BreakpointEventBody {
   /// The reason for the event.
@@ -24,16 +20,14 @@ pub struct BreakpointEventBody {
 }
 
 //// Arguments for a Capabilities event
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CapabilitiesEventBody {
   pub capabilities: Capabilities,
 }
 
 //// Arguments for a Continued event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinuedEventBody {
   /// The thread which was continued.
@@ -44,8 +38,7 @@ pub struct ContinuedEventBody {
 }
 
 //// Arguments for a Exited event
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExitedEventBody {
   /// The exit code returned from the debuggee.
@@ -53,8 +46,7 @@ pub struct ExitedEventBody {
 }
 
 //// Arguments for a Invalidated event
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InvalidatedEventBody {
   /// Set of logical areas that got invalidated. This property has a hint
@@ -72,8 +64,7 @@ pub struct InvalidatedEventBody {
 }
 
 //// Arguments for a LoadedSource event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LoadedSourceEventBody {
   /// The reason for the event.
@@ -84,8 +75,7 @@ pub struct LoadedSourceEventBody {
 }
 
 //// Arguments for a Memory event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MemoryEventBody {
   /// Memory reference of a memory range that has been updated.
@@ -97,8 +87,7 @@ pub struct MemoryEventBody {
 }
 
 //// Arguments for a Module event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ModuleEventBody {
   /// The reason for the event.
@@ -110,8 +99,7 @@ pub struct ModuleEventBody {
 }
 
 //// Arguments for an Output event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct OutputEventBody {
   /// The output category. If not specified or if the category is not
@@ -167,8 +155,7 @@ pub struct OutputEventBody {
 }
 
 //// Arguments for an Process event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessEventBody {
   /// The logical name of the process. This is usually the full path to
@@ -193,8 +180,7 @@ pub struct ProcessEventBody {
 }
 
 //// Arguments for a ProgressEnd event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProgressEndEventBody {
   /// The ID that was introduced in the initial `ProgressStartEvent`.
@@ -205,8 +191,7 @@ pub struct ProgressEndEventBody {
 }
 
 //// Arguments for a ProgressStart event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProgressStartEventBody {
   /// An ID that can be used in subsequent `progressUpdate` and `progressEnd`
@@ -237,8 +222,7 @@ pub struct ProgressStartEventBody {
 }
 
 //// Arguments for a ProgressUpdate event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProgressUpdateEventBody {
   /// The ID that was introduced in the initial `progressStart` event.
@@ -252,8 +236,7 @@ pub struct ProgressUpdateEventBody {
 }
 
 //// Arguments for a Stopped event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StoppedEventBody {
   /// The reason for the event.
@@ -292,8 +275,7 @@ pub struct StoppedEventBody {
 }
 
 //// Arguments for a Terminated event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminatedEventBody {
   /// A debug adapter may set `restart` to true (or to an arbitrary object) to
@@ -304,8 +286,7 @@ pub struct TerminatedEventBody {
 }
 
 //// Arguments for a Thread event.
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadEventBody {
   /// The reason for the event.
@@ -315,8 +296,7 @@ pub struct ThreadEventBody {
   pub thread_id: i64,
 }
 
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "event", content = "body", rename_all = "camelCase")]
 pub enum Event {
   /// This event indicates that the debug adapter is ready to accept configuration requests (e.g.

--- a/dap/src/requests.rs
+++ b/dap/src/requests.rs
@@ -1,8 +1,5 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-#[cfg(feature = "client")]
-use serde::Serialize;
 
 use crate::{
   errors::ServerError,
@@ -15,8 +12,7 @@ use crate::{
   },
 };
 
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum PathFormat {
   Path,
@@ -27,8 +23,7 @@ pub enum PathFormat {
 
 //// Arguments for an Initialize request.
 /// In specification: [Initialize](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize)
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeArguments {
   /// The ID of the client using this adapter.
@@ -70,8 +65,7 @@ pub struct InitializeArguments {
 
 //// Arguments for an SetBreakpoints request.
 /// In specification: [SetBreakpoints](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize)
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetBreakpointsArguments {
   /// The source location of the breakpoints, either `source.path` or
@@ -87,8 +81,7 @@ pub struct SetBreakpointsArguments {
   pub source_modified: Option<bool>,
 }
 
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelArguments {
   /// The ID (attribute `seq`) of the request to cancel. If missing no request is
@@ -101,8 +94,7 @@ pub struct CancelArguments {
   pub progress_id: Option<String>,
 }
 
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetExceptionBreakpointsArguments {
   /// Set of exception filters specified by their ID. The set of all possible
@@ -121,8 +113,7 @@ pub struct SetExceptionBreakpointsArguments {
   pub exception_options: Option<Vec<ExceptionOptions>>,
 }
 
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetFunctionBreakpointsArguments {
   /// The function names of the breakpoints.
@@ -130,8 +121,7 @@ pub struct SetFunctionBreakpointsArguments {
 }
 
 //// Arguments for a Launch request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LaunchRequestArguments {
   /// If true, the launch request should launch the program without enabling
@@ -151,8 +141,7 @@ pub struct LaunchRequestArguments {
 }
 
 //// Arguments for an Attach request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AttachRequestArguments {
   /// Arbitrary data from the previous, restarted session.
@@ -168,8 +157,7 @@ pub struct AttachRequestArguments {
 
 //// Union of Attach and Launch arguments for the Restart request.
 //// Currently the same as LaunchRequestArguments but might not be in the future.
-#[derive(Deserialize, Debug, Default, Clone)]
-#[cfg_attr(feature = "client", derive(Serialize))]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AttachOrLaunchArguments {
   /// If true, the launch request should launch the program without enabling
@@ -188,8 +176,7 @@ pub struct AttachOrLaunchArguments {
 }
 
 //// Arguments for a BreakpointLocations request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BreakpointLocationsArguments {
   /// The source location of the breakpoints, either `source.path` or
@@ -214,8 +201,7 @@ pub struct BreakpointLocationsArguments {
 }
 
 //// Arguments for a Completions request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionsArguments {
   /// Returns completions in the scope of this stack frame. If not specified, the
@@ -234,8 +220,7 @@ pub struct CompletionsArguments {
 }
 
 //// Arguments for a Continue request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueArguments {
   /// Specifies the active thread. If the debug adapter supports single thread
@@ -248,8 +233,7 @@ pub struct ContinueArguments {
 }
 
 //// Arguments for a DataBreakpointInfo request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataBreakpointInfoArguments {
   /// Reference to the variable container if the data breakpoint is requested for
@@ -268,8 +252,7 @@ pub struct DataBreakpointInfoArguments {
 }
 
 //// Arguments for a Disassemble request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DisassembleArguments {
   /// Memory reference to the base location containing the instructions to
@@ -293,8 +276,7 @@ pub struct DisassembleArguments {
 }
 
 //// Arguments for a Disconnect request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DisconnectArguments {
   /// A value of true indicates that this `disconnect` request is part of a
@@ -315,8 +297,7 @@ pub struct DisconnectArguments {
 }
 
 //// Arguments for a Evaluate request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateArguments {
   /// The expression to evaluate.
@@ -344,8 +325,7 @@ pub struct EvaluateArguments {
 }
 
 /// Arguments for a ExceptionInfo request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionInfoArguments {
   /// Thread for which exception information should be retrieved.
@@ -353,8 +333,7 @@ pub struct ExceptionInfoArguments {
 }
 
 /// Arguments for a Goto request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GotoArguments {
   /// Set the goto target for this thread.
@@ -364,8 +343,7 @@ pub struct GotoArguments {
 }
 
 /// Arguments for a GotoTargets request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GotoTargetsArguments {
   /// The source location for which the goto targets are determined.
@@ -379,8 +357,7 @@ pub struct GotoTargetsArguments {
 }
 
 /// Arguments for a Modules request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ModulesArguments {
   /// The index of the first module to return, if omitted modules start at 0.
@@ -391,8 +368,7 @@ pub struct ModulesArguments {
 }
 
 /// Arguments for a Next request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct NextArguments {
   /// Specifies the thread for which to resume execution for one step (of the
@@ -406,8 +382,7 @@ pub struct NextArguments {
 }
 
 /// Arguments for a Pause request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PauseArguments {
   /// Pause execution for this thread.
@@ -415,8 +390,7 @@ pub struct PauseArguments {
 }
 
 /// Arguments for a ReadMemory request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadMemoryArguments {
   /// Memory reference to the base location from which data should be read.
@@ -429,16 +403,14 @@ pub struct ReadMemoryArguments {
 }
 
 /// Arguments for a ReadMemory request.
-#[derive(Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "client", derive(Serialize))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RestartArguments {
   pub arguments: Option<AttachOrLaunchArguments>,
 }
 
 /// Arguments for a RestartFrame request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RestartFrameArguments {
   /// Restart this stackframe.
@@ -446,8 +418,7 @@ pub struct RestartFrameArguments {
 }
 
 /// Arguments for a ReverseContinue request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ReverseContinueArguments {
   /// Specifies the active thread. If the debug adapter supports single thread
@@ -460,8 +431,7 @@ pub struct ReverseContinueArguments {
 }
 
 /// Arguments for a Scopes request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ScopesArguments {
   /// Retrieve the scopes for this stackframe.
@@ -469,8 +439,7 @@ pub struct ScopesArguments {
 }
 
 /// Arguments for a SetDataBreakpoints request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetDataBreakpointsArguments {
   /// The contents of this array replaces all existing data breakpoints. An empty
@@ -479,8 +448,7 @@ pub struct SetDataBreakpointsArguments {
 }
 
 /// Arguments for a SetExpression request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetExpressionArguments {
   /// The l-value expression to assign to.
@@ -495,8 +463,7 @@ pub struct SetExpressionArguments {
 }
 
 /// Arguments for a SetExpression request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetInstructionBreakpointsArguments {
   /// The instruction references of the breakpoints
@@ -504,8 +471,7 @@ pub struct SetInstructionBreakpointsArguments {
 }
 
 /// Arguments for a SetVariable request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SetVariableArguments {
   /// The reference of the variable container.
@@ -521,8 +487,7 @@ pub struct SetVariableArguments {
 }
 
 /// Arguments for a Source request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceArguments {
   /// Specifies the source content to load. Either `source.path` or
@@ -535,8 +500,7 @@ pub struct SourceArguments {
 }
 
 /// Arguments for a StackTrace request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StackTraceArguments {
   /// Retrieve the stacktrace for this thread.
@@ -553,8 +517,7 @@ pub struct StackTraceArguments {
 }
 
 /// Arguments for a StepBack request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StepBackArguments {
   /// Specifies the thread for which to resume execution for one step backwards
@@ -568,8 +531,7 @@ pub struct StepBackArguments {
 }
 
 /// Arguments for a StepIn request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StepInArguments {
   /// Specifies the thread for which to resume execution for one step-into (of
@@ -585,8 +547,7 @@ pub struct StepInArguments {
 }
 
 /// Arguments for a StepInTargets request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StepInTargetsArguments {
   /// The stack frame for which to retrieve the possible step-in targets.
@@ -594,8 +555,7 @@ pub struct StepInTargetsArguments {
 }
 
 /// Arguments for a StepOut request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StepOutArguments {
   /// Specifies the thread for which to resume execution for one step-out (of the
@@ -609,8 +569,7 @@ pub struct StepOutArguments {
 }
 
 /// Arguments for a Terminate request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminateArguments {
   /// A value of true indicates that this `terminate` request is part of a
@@ -619,8 +578,7 @@ pub struct TerminateArguments {
 }
 
 /// Arguments for a TerminateThreads request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminateThreadsArguments {
   /// Ids of threads to be terminated.
@@ -628,8 +586,7 @@ pub struct TerminateThreadsArguments {
 }
 
 /// Arguments for a Variables request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VariablesArguments {
   /// The variable for which to retrieve its children. The `variablesReference`
@@ -653,8 +610,7 @@ pub struct VariablesArguments {
 }
 
 /// Arguments for a WriteMemory request.
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WriteMemoryArguments {
   /// Memory reference to the base location to which data should be written.
@@ -674,8 +630,7 @@ pub struct WriteMemoryArguments {
   pub data: String,
 }
 
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "command", content = "arguments", rename_all = "camelCase")]
 pub enum Command {
   /// The attach request is sent from the client to the debug adapter to attach to a debuggee that
@@ -1000,8 +955,7 @@ pub enum Command {
 /// interface. Instead, the only common part (the sequence number) is repeated in the struct.
 ///
 /// Specification: [Request](https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_Request)
-#[cfg_attr(feature = "client", derive(Serialize))]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Request {
   /// Sequence number for the Request.

--- a/dap/src/responses.rs
+++ b/dap/src/responses.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "integration_testing")]
 use fake::Dummy;
-use serde::Serialize;
-
-#[cfg(feature = "client")]
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::{
   Breakpoint, BreakpointLocation, Capabilities, CompletionItem, DataBreakpointAccessType,
@@ -12,9 +9,8 @@ use crate::types::{
 };
 
 /// Represents a response message that is either a cancellation or a short error string.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub enum ResponseMessage {
   /// Should be sent when the request was canceled
@@ -27,27 +23,24 @@ pub enum ResponseMessage {
   Error(String),
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct BreakpointLocationsResponse {
   /// Sorted set of possible breakpoint locations.
   pub breakpoints: Vec<BreakpointLocation>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct CompletionsResponse {
   /// The possible completions
   pub targets: Vec<CompletionItem>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ContinueResponse {
   /// The value true (or a missing property) signals to the client that all
@@ -57,9 +50,8 @@ pub struct ContinueResponse {
   pub all_threads_continued: Option<bool>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct DataBreakpointInfoResponse {
   /// An identifier for the data on which a data breakpoint can be registered
@@ -84,18 +76,16 @@ pub struct DataBreakpointInfoResponse {
   pub can_persist: Option<bool>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct DisassembleResponse {
   /// The list of disassembled instructions.
   pub instructions: Vec<DisassembledInstruction>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct EvaluateResponse {
   /// The result of the evaluate request.
@@ -137,9 +127,8 @@ pub struct EvaluateResponse {
   pub memory_reference: Option<String>,
 }
 
-#[derive(Serialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ExceptionInfoResponse {
   /// ID of the exception that was thrown.
@@ -154,27 +143,24 @@ pub struct ExceptionInfoResponse {
   pub details: Option<ExceptionDetails>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct GotoTargetsResponse {
   /// The possible goto targets of the specified location.
   pub targets: Vec<GotoTarget>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct LoadedSourcesResponse {
   /// Set of loaded sources.
   pub sources: Vec<Source>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ModulesResponse {
   /// All modules or range of modules.
@@ -184,9 +170,8 @@ pub struct ModulesResponse {
   pub total_modules: Option<i64>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ReadMemoryResponse {
   /// The address of the first byte of data returned.
@@ -204,9 +189,8 @@ pub struct ReadMemoryResponse {
   pub data: Option<String>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ScopesResponse {
   /// The scopes of the stackframe. If the array has length zero, there are no
@@ -214,9 +198,8 @@ pub struct ScopesResponse {
   pub scopes: Vec<Scope>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetBreakpointsResponse {
   /// Information about the breakpoints.
@@ -225,9 +208,8 @@ pub struct SetBreakpointsResponse {
   pub breakpoints: Vec<Breakpoint>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetDataBreakpointsResponse {
   /// Information about the breakpoints.
@@ -236,9 +218,8 @@ pub struct SetDataBreakpointsResponse {
   pub breakpoints: Vec<Breakpoint>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetExceptionBreakpointsResponse {
   /// Information about the exception breakpoints or filters.
@@ -251,9 +232,8 @@ pub struct SetExceptionBreakpointsResponse {
   pub breakpoints: Option<Vec<Breakpoint>>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetFunctionBreakpointsResponse {
   /// Information about the breakpoints. The array elements correspond to the
@@ -261,9 +241,8 @@ pub struct SetFunctionBreakpointsResponse {
   pub breakpoints: Vec<Breakpoint>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetInstructionBreakpointsResponse {
   /// Information about the breakpoints. The array elements correspond to the
@@ -271,9 +250,8 @@ pub struct SetInstructionBreakpointsResponse {
   pub breakpoints: Vec<Breakpoint>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetVariableResponse {
   /// The new value of the variable.
@@ -304,9 +282,8 @@ pub struct SetVariableResponse {
   pub indexed_variables: Option<i32>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SourceResponse {
   /// Content of the source reference.
@@ -316,9 +293,8 @@ pub struct SourceResponse {
   pub mime_type: Option<String>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct SetExpressionResponse {
   /// The new value of the expression.
@@ -354,9 +330,8 @@ pub struct SetExpressionResponse {
   pub indexed_variables: Option<i32>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct StackTraceResponse {
   /// The frames of the stackframe. If the array has length zero, there are no
@@ -373,27 +348,24 @@ pub struct StackTraceResponse {
   pub total_frames: Option<i64>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct ThreadsResponse {
   /// All threads.
   pub threads: Vec<Thread>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct VariablesResponse {
   /// All (or a range) of variables for the given variable reference.
   pub variables: Vec<Variable>,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct WriteMemoryResponse {
   /// Property that should be returned when `allowPartial` is true to indicate
@@ -407,9 +379,8 @@ pub struct WriteMemoryResponse {
   pub bytes_written: Option<i64>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "command", content = "body", rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub enum ResponseBody {
   /// Response to attach request. This is just an acknowledgement, so no body field is required.
@@ -635,9 +606,8 @@ pub enum ResponseBody {
 /// ResponseBody enum.
 ///
 /// Specification: [Response](https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_Response)
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
 pub struct Response {
   /// Sequence number of the corresponding request.

--- a/dap/src/reverse_requests.rs
+++ b/dap/src/reverse_requests.rs
@@ -1,14 +1,10 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
-
-#[cfg(feature = "client")]
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::{RunInTerminalRequestArgumentsKind, StartDebuggingRequestKind};
 
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RunInTerminalRequestArguments {
   /// What kind of terminal to launch.
@@ -33,8 +29,7 @@ pub struct RunInTerminalRequestArguments {
   pub args_can_be_interpreted_by_shell: Option<bool>,
 }
 
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StartDebuggingRequestArguments {
   /// Arguments passed to the new debug session. The arguments must only contain
@@ -48,8 +43,7 @@ pub struct StartDebuggingRequestArguments {
   pub request: StartDebuggingRequestKind,
 }
 
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "command", content = "arguments", rename_all = "camelCase")]
 pub enum ReverseCommand {
   /// This request is sent from the debug adapter to the client to run a command in a terminal.
@@ -90,8 +84,7 @@ pub enum ReverseCommand {
 /// beneficial to separate them because then we don't need to generate a huge
 /// amount of serialization code for all requests and supporting types (that the
 /// vast majority of would never be serialized by the adapter, only deserialized).
-#[cfg_attr(feature = "client", derive(Deserialize))]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ReverseRequest {
   /// Sequence number for the Request.

--- a/dap/src/server.rs
+++ b/dap/src/server.rs
@@ -2,8 +2,6 @@ use std::fmt::Debug;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::sync::{Arc, Mutex};
 
-use serde_json;
-
 use crate::{
   base_message::{BaseMessage, Sendable},
   errors::{DeserializationError, ServerError},

--- a/dap/src/types.rs
+++ b/dap/src/types.rs
@@ -1338,10 +1338,9 @@ pub enum StartDebuggingRequestKind {
 /// A structured message object. Used to return errors from requests.
 ///
 /// Specification: [Message](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Message)
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "integration_testing", derive(Dummy))]
-#[cfg_attr(feature = "client", derive(Deserialize))]
 pub struct Message {
   /// Unique (within a debug adapter implementation) identifier for the message.
   /// The purpose of these error IDs is to help extension authors that have the


### PR DESCRIPTION
# Motivation

When building a DAP _client_, we may want to send `Request`s. This is not currently supported in the upstream crate.

# Changes

- Make all DAP types `Serialize` _and_ `Deserialize`
- Remove the `client` feature since it's not needed any more
- Remove the `publish` CI step as we are not the canonical source of the `dap` crate

